### PR TITLE
Allow specifying the base url

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ http://rvm.io/binaries/ubuntu/12.04/x86_64/ruby-1.8.2.tar.bz2 cannot be reached
 Cannot found a built version of ruby '1.8.2' compiled for your current system: Ubuntu x86_64 (12.04)
 ```
 
+Example: trying to install from a different URL
+```
+vagrant@precise64:~$ RVM_BINARIES_BASE=https://internal.example.com/rubies rbenv download 1.8.2
+Download and extract ruby 1.8.2 from RVM repository
+https://internal.example.com/rubies/ubuntu/12.04/x86_64/ruby-1.8.2.tar.bz2 cannot be reached
+Cannot found a built version of ruby '1.8.2' compiled for your current system: Ubuntu x86_64 (12.04)
+```
+
 ## Troubleshooting
 
 ###  It seems your ruby installation is missing psych (for YAML output)

--- a/bin/rbenv-download
+++ b/bin/rbenv-download
@@ -14,7 +14,7 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-RVM_BINARIES_BASE="http://rvm.io/binaries"
+RVM_BINARIES_BASE=${RVM_BINARIES_BASE:-"http://rvm.io/binaries"}
 RUBIES_ROOT="${RBENV_ROOT}/versions"
 
 source "$(dirname $BASH_SOURCE)/../lib/rvm_import.sh"


### PR DESCRIPTION
Allow overriding the URL where packages are stored (useful for e.g. when using internal package repositories)
