### PR TITLE
Use HTTPS when downloading from rvm.io

### DIFF
--- a/bin/rbenv-download
+++ b/bin/rbenv-download
@@ -14,7 +14,7 @@ if [ -z "$1" ]; then
   exit 1
 fi
 
-RVM_BINARIES_BASE=${RVM_BINARIES_BASE:-"http://rvm.io/binaries"}
+RVM_BINARIES_BASE=${RVM_BINARIES_BASE:-"https://rvm.io/binaries"}
 RUBIES_ROOT="${RBENV_ROOT}/versions"
 
 source "$(dirname $BASH_SOURCE)/../lib/rvm_import.sh"


### PR DESCRIPTION
Since HTTPS is present on rvm.io, use it when downloading Ruby binaries. This adds a bit of privacy for users, reduces attacker insight into the versions of Ruby running on a system, and overall contributes to the level of encrypted traffic in the world.