### PR TITLE
Fixes download URL for RedHat systems

### DIFF
--- a/lib/rvm_import.sh
+++ b/lib/rvm_import.sh
@@ -113,7 +113,7 @@ __rvm_detect_system()
         _system_name="$(
           GREP_OPTIONS="" \grep -Eo 'CentOS|ClearOS|Mageia|Scientific' /etc/redhat-release 2>/dev/null
         )" ||
-        _system_name="RedHat"
+        _system_name="CentOS"
         _system_version="$(GREP_OPTIONS="" \grep -Eo '[0-9\.]+' /etc/redhat-release | \awk -F. 'NR==1{print $1}')"
       else
         _system_version="libc-$(ldd --version | \awk 'NR==1 {print $NF}' | \awk -F. '{print $1"."$2}')"


### PR DESCRIPTION
There is no "redhat" directory in https://rvm.io/binaries, so this sets the OS to CentOS if you're using a RedHat system.  Could be a more intelligent way to do it but this works just fine.

One flaw is that if a version cannot be found to download it will say say current system is CentOS and not RedHat, i.e. it will show `Cannot find a built version of  '2.1.0' compiled for your current system: CentOS x86_64 (6)` and not `Cannot find a built version of  '2.1.0' compiled for your current system: RedHat x86_64 (6)` on RedHat systems.
