### PR TITLE
Use mkdir -p instead of mkdir --parents

### DIFF
--- a/lib/functions.sh
+++ b/lib/functions.sh
@@ -28,5 +28,5 @@ rename_folder_if_exist() {
 
 ensure_folder_exists() {
   folder=$1
-  mkdir --parents $folder
+  mkdir -p $folder
 }


### PR DESCRIPTION
The --parents switch is not available on either BSD or OS X, but
the -p switch is available on GNU/Linux, BSD and OS X.

Fixes #13